### PR TITLE
Don't use CTE to calculate BlobIds

### DIFF
--- a/src/Sitecore.DataBlaster/Load/Sql/08.MergeTempData.sql
+++ b/src/Sitecore.DataBlaster/Load/Sql/08.MergeTempData.sql
@@ -182,6 +182,19 @@ FROM
 OPTION (MAXRECURSION 1000)
 
 
+-- For all non 'addOnly' blobs, we need cleanup the obsolete 
+-- blob chunks. Store ids of those blobs in a temp table.
+SELECT 
+	DISTINCT CAST(bif.Value AS UNIQUEIDENTIFIER) AS BlobId
+INTO
+	#blobsToCleanup
+FROM
+	#BulkItemsAndFields bif
+WHERE 
+	bif.IsBlob = 1
+	AND DATALENGTH(bif.Blob) > 0
+    AND bif.FieldAction != 'AddOnly'
+
 -- Upsert blobs.
 PRINT CONVERT(VARCHAR(12), GETDATE(), 114) + ': Upserting blobs...'
 DECLARE @BlobChunkSize INT = 1029120 -- Hardcoded value copied from Sitecore SqlServerDataProvider.BlobChunkSize
@@ -239,7 +252,7 @@ WHEN MATCHED AND CAST(target.Data AS VARBINARY(MAX)) != CAST(source.Chunk AS VAR
 WHEN NOT MATCHED BY TARGET THEN
 	INSERT (Id, BlobId, [Index], Data, Created)
 	VALUES (NEWID(), source.BlobId, source.Idx, source.Chunk, @Timestamp)
-WHEN NOT MATCHED BY SOURCE AND target.BlobId IN (SELECT DISTINCT BlobId FROM BlobCte) THEN 
+WHEN NOT MATCHED BY SOURCE AND target.BlobId IN (SELECT BlobId FROM #blobsToCleanup) THEN 
     DELETE
 ;
 


### PR DESCRIPTION
The BlobCTE was used in to determine for which blobs we should cleanup 'chunks' that are no longer relevant (case were the new blob is smaller than the old blob).

Using that CTE is a bit overkill, because it will re-calculate the chunks over and over again and we only need the BlobIds in that case.

In our test, we deserialized a Sitecore tree with multiple sites and about 479 blobs. Before the enhancement that took +1h, afterwards about 6 minutes.