### PR TITLE
Add support for clearing all caches during a bulk load operation

### DIFF
--- a/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
+++ b/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
@@ -83,14 +83,28 @@ namespace Sitecore.DataBlaster.Load
         /// <summary>
         /// Whether to remove updated items from Sitecore caches. Enabled by default.
         /// </summary>
-        public bool RemoveItemsFromCaches { get; set; }
+        public bool UpdateCaches { get; set; }
 
         /// <summary>
-        /// Whether to clear the entire caches (<value>true</value>), or to remove impacted cache entries only (<value>false</value>; default).
-        /// When both the imported data set and the Sitecore caches are quite large, there is a performance impact in scanning the caches for entries that must be deleted.
-        /// In this case it could prove more useful to just clear the caches instead of spending time to scan them. The performance impact is then in repopulation, though.
+        /// This property has been replaced by <see cref="UpdateCaches"/>.
         /// </summary>
-        public bool ClearEntireCaches { get; set; }
+        [Obsolete("Use UpdateCaches instead.", false)]
+        public bool RemoveItemsFromCaches
+        {
+            get { return this.UpdateCaches; }
+            set { this.UpdateCaches = value; }
+        }
+
+        /// <summary>
+        /// If <see cref="UpdateCaches"/> is set to <value>true</value> then this property defines the strategy for removing entries from the cache; otherwise this property has no effect.
+        /// If <value>false</value> (default), only entries for impacted items are removed from the cache. If <value>true</value>, the caches are cleared instead.
+        /// <remarks>
+        /// When both the imported data set and the Sitecore caches are quite large, there is a performance impact in scanning the caches for entries that must be deleted.
+        /// In this case it could prove more useful to just clear the caches, instead of spending time to scan them. The performance impact is then in repopulation, though.
+        /// For settings that have an impact on cache removal performance, see <see cref="Sitecore.Configuration.Settings.Caching.CacheKeyIndexingEnabled"/>.
+        /// </remarks>
+        /// </summary>
+        public bool ClearCaches { get; set; }
 
         /// <summary>
         /// Whether to update the history engine of Sitecore. This engine is e.g. used for index syncs.
@@ -171,7 +185,7 @@ namespace Sitecore.DataBlaster.Load
             if (string.IsNullOrEmpty(database)) throw new ArgumentNullException(nameof(database));
 
             Database = database;
-            RemoveItemsFromCaches = true;
+            UpdateCaches = true;
             UpdateIndexes = true;
 
             Log = LoggerFactory.GetLogger(typeof(BulkLoader));

--- a/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
+++ b/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
@@ -86,6 +86,13 @@ namespace Sitecore.DataBlaster.Load
         public bool RemoveItemsFromCaches { get; set; }
 
         /// <summary>
+        /// Whether to clear the entire caches (<value>true</value>), or to remove impacted cache entries only (<value>false</value>; default).
+        /// When both the imported data set and the Sitecore caches are quite large, there is a performance impact in scanning the caches for entries that must be deleted.
+        /// In this case it could prove more useful to just clear the caches instead of spending time to scan them. The performance impact is then in repopulation, though.
+        /// </summary>
+        public bool ClearEntireCaches { get; set; }
+
+        /// <summary>
         /// Whether to update the history engine of Sitecore. This engine is e.g. used for index syncs.
         /// </summary>
         public bool? UpdateHistory { get; set; }

--- a/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
+++ b/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
@@ -82,27 +82,17 @@ namespace Sitecore.DataBlaster.Load
 
         /// <summary>
         /// Whether to remove updated items from Sitecore caches. Enabled by default.
+        /// This setting is not impacted by the value of <seealso cref="ClearCaches"/>.
         /// </summary>
-        public bool UpdateCaches { get; set; }
+        public bool RemoveItemsFromCaches { get; set; }
 
         /// <summary>
-        /// This property has been replaced by <see cref="UpdateCaches"/>.
-        /// </summary>
-        [Obsolete("Use UpdateCaches instead.", false)]
-        public bool RemoveItemsFromCaches
-        {
-            get { return this.UpdateCaches; }
-            set { this.UpdateCaches = value; }
-        }
-
-        /// <summary>
-        /// If <see cref="UpdateCaches"/> is set to <value>true</value> then this property defines the strategy for removing entries from the cache; otherwise this property has no effect.
-        /// If <value>false</value> (default), only entries for impacted items are removed from the cache. If <value>true</value>, the caches are cleared instead.
-        /// <remarks>
+        /// Offers an alternative strategy to remove items from Sitecore caches, by clearing them completely.
+        /// This setting is not impacted by the value of <seealso cref="RemoveItemsFromCaches"/>.
+        /// 
         /// When both the imported data set and the Sitecore caches are quite large, there is a performance impact in scanning the caches for entries that must be deleted.
         /// In this case it could prove more useful to just clear the caches, instead of spending time to scan them. The performance impact is then in repopulation, though.
         /// For settings that have an impact on cache removal performance, see <see cref="Sitecore.Configuration.Settings.Caching.CacheKeyIndexingEnabled"/>.
-        /// </remarks>
         /// </summary>
         public bool ClearCaches { get; set; }
 
@@ -185,7 +175,7 @@ namespace Sitecore.DataBlaster.Load
             if (string.IsNullOrEmpty(database)) throw new ArgumentNullException(nameof(database));
 
             Database = database;
-            UpdateCaches = true;
+            RemoveItemsFromCaches = true;
             UpdateIndexes = true;
 
             Log = LoggerFactory.GetLogger(typeof(BulkLoader));

--- a/src/Sitecore.DataBlaster/Load/Processors/ChangeCacheClearer.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/ChangeCacheClearer.cs
@@ -20,16 +20,16 @@ namespace Sitecore.DataBlaster.Load.Processors
 
         public void Process(BulkLoadContext loadContext, BulkLoadSqlContext sqlContext, ICollection<ItemChange> changes)
         {
-            if (!loadContext.RemoveItemsFromCaches) return;
+            if (!loadContext.UpdateCaches) return;
 
             var stopwatch = Stopwatch.StartNew();
 
             // Remove items from database cache.
             // We don't do this within the transaction so that items will be re-read from the committed data.
             var db = Factory.GetDatabase(loadContext.Database, true);
-            if (loadContext.ClearEntireCaches)
+            if (loadContext.ClearCaches)
             {
-                _cachUtil.ClearAllCaches(db);
+                _cachUtil.ClearCaches(db);
                 loadContext.Log.Info($"Caches cleared (full): {(int)stopwatch.Elapsed.TotalSeconds}s");
             }
             else

--- a/src/Sitecore.DataBlaster/Load/Processors/ChangeCacheClearer.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/ChangeCacheClearer.cs
@@ -27,9 +27,16 @@ namespace Sitecore.DataBlaster.Load.Processors
             // Remove items from database cache.
             // We don't do this within the transaction so that items will be re-read from the committed data.
             var db = Factory.GetDatabase(loadContext.Database, true);
-            _cachUtil.RemoveItemsFromCachesInBulk(db, GetCacheClearEntries(loadContext.ItemChanges));
-
-            loadContext.Log.Info($"Caches cleared: {(int) stopwatch.Elapsed.TotalSeconds}s");
+            if (loadContext.ClearEntireCaches)
+            {
+                _cachUtil.ClearAllCaches(db);
+                loadContext.Log.Info($"Caches cleared (full): {(int)stopwatch.Elapsed.TotalSeconds}s");
+            }
+            else
+            {
+                _cachUtil.RemoveItemsFromCachesInBulk(db, GetCacheClearEntries(loadContext.ItemChanges));
+                loadContext.Log.Info($"Caches cleared: {(int)stopwatch.Elapsed.TotalSeconds}s");
+            }
         }
 
         protected virtual IEnumerable<Tuple<ID, ID, string>> GetCacheClearEntries(IEnumerable<ItemChange> itemChanges)

--- a/src/Sitecore.DataBlaster/Load/Processors/ChangeCacheClearer.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/ChangeCacheClearer.cs
@@ -20,7 +20,7 @@ namespace Sitecore.DataBlaster.Load.Processors
 
         public void Process(BulkLoadContext loadContext, BulkLoadSqlContext sqlContext, ICollection<ItemChange> changes)
         {
-            if (!loadContext.UpdateCaches) return;
+            if (!loadContext.RemoveItemsFromCaches && !loadContext.ClearCaches) return;
 
             var stopwatch = Stopwatch.StartNew();
 
@@ -30,12 +30,12 @@ namespace Sitecore.DataBlaster.Load.Processors
             if (loadContext.ClearCaches)
             {
                 _cachUtil.ClearCaches(db);
-                loadContext.Log.Info($"Caches cleared (full): {(int)stopwatch.Elapsed.TotalSeconds}s");
+                loadContext.Log.Info($"Caches cleared: {(int)stopwatch.Elapsed.TotalSeconds}s");
             }
             else
             {
                 _cachUtil.RemoveItemsFromCachesInBulk(db, GetCacheClearEntries(loadContext.ItemChanges));
-                loadContext.Log.Info($"Caches cleared: {(int)stopwatch.Elapsed.TotalSeconds}s");
+                loadContext.Log.Info($"Items removed from cache: {(int) stopwatch.Elapsed.TotalSeconds}s");
             }
         }
 

--- a/src/Sitecore.DataBlaster/Util/CacheUtil.cs
+++ b/src/Sitecore.DataBlaster/Util/CacheUtil.cs
@@ -118,7 +118,7 @@ namespace Sitecore.DataBlaster.Util
             cache.Remove(database.Name);
         }
 
-        public virtual void ClearAllCaches(Database database)
+        public virtual void ClearCaches(Database database)
         {
             if (database == null) throw new ArgumentNullException(nameof(database));
 

--- a/src/Sitecore.DataBlaster/Util/CacheUtil.cs
+++ b/src/Sitecore.DataBlaster/Util/CacheUtil.cs
@@ -117,5 +117,26 @@ namespace Sitecore.DataBlaster.Util
                 true);
             cache.Remove(database.Name);
         }
+
+        public virtual void ClearAllCaches(Database database)
+        {
+            if (database == null) throw new ArgumentNullException(nameof(database));
+
+            var current = Context.Database;
+            try
+            {
+                // http://www.theinsidecorner.com/en/Developers/Caching/CacheStates/ClearAllCaches
+                // http://stackoverflow.com/questions/3713031/sitecore-clear-cache-programatically
+
+                Context.Database = database;
+                Context.Database.Engines.TemplateEngine.Reset();
+                Context.ClientData.RemoveAll();
+                CacheManager.ClearAllCaches();
+            }
+            finally
+            {
+                if (current != null) Context.Database = current;
+            }
+        }
     }
 }

--- a/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
+++ b/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
@@ -202,7 +202,7 @@ namespace Unicorn.DataBlaster.Sync
             context.StageDataWithoutProcessing = parameters.StageDataWithoutProcessing;
 
             // Use the shotgun, removing items one by one is too slow for full deserialize.
-            context.RemoveItemsFromCaches = false;
+            context.UpdateCaches = false;
 
             context.UpdateHistory = !SkipHistoryEngine;
             context.UpdatePublishQueue = !SkipPublishQueue;

--- a/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
+++ b/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
@@ -202,7 +202,7 @@ namespace Unicorn.DataBlaster.Sync
             context.StageDataWithoutProcessing = parameters.StageDataWithoutProcessing;
 
             // Use the shotgun, removing items one by one is too slow for full deserialize.
-            context.UpdateCaches = false;
+            context.RemoveItemsFromCaches = false;
 
             context.UpdateHistory = !SkipHistoryEngine;
             context.UpdatePublishQueue = !SkipPublishQueue;


### PR DESCRIPTION
In certain scenarios (like during deployment), we're not interested in removing the correct entries from the caches, but we want speed! This change provides a setting on the `BulkLoadContext` to do just that.