### PR TITLE
Apply sorting of using + spacing rules.

### DIFF
--- a/src/Sitecore.DataBlaster/BulkItem.cs
+++ b/src/Sitecore.DataBlaster/BulkItem.cs
@@ -292,7 +292,7 @@ namespace Sitecore.DataBlaster
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
                 if (obj.GetType() != this.GetType()) return false;
-                return Equals((BulkFieldKey) obj);
+                return Equals((BulkFieldKey)obj);
             }
 
             public override int GetHashCode()

--- a/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
+++ b/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
@@ -301,14 +301,14 @@ namespace Sitecore.DataBlaster.Load
 
             var cache = GetPathCache();
             Guid id;
-            return cache.TryGetValue(itemPath, out id) ? id : (Guid?) null;
+            return cache.TryGetValue(itemPath, out id) ? id : (Guid?)null;
         }
 
         public virtual Guid? GetProcessedItemTemplateId(Guid itemId)
         {
             var cache = GetTemplateCache();
             Guid id;
-            return cache.TryGetValue(itemId, out id) ? id : (Guid?) null;
+            return cache.TryGetValue(itemId, out id) ? id : (Guid?)null;
         }
 
         #endregion
@@ -333,7 +333,7 @@ namespace Sitecore.DataBlaster.Load
             {
                 return defaultValue;
             }
-            return (T) state;
+            return (T)state;
         }
 
         /// <summary>
@@ -352,7 +352,7 @@ namespace Sitecore.DataBlaster.Load
                 state = stateFactory();
                 _state[key] = state;
             }
-            return (T) state;
+            return (T)state;
         }
 
         #endregion

--- a/src/Sitecore.DataBlaster/Load/BulkLoader.cs
+++ b/src/Sitecore.DataBlaster/Load/BulkLoader.cs
@@ -11,7 +11,6 @@ using Sitecore.Configuration;
 using Sitecore.Data.Managers;
 using Sitecore.DataBlaster.Load.Processors;
 using Sitecore.DataBlaster.Load.Sql;
-using Sitecore.DataBlaster.Read;
 using Sitecore.DataBlaster.Util;
 using Sitecore.DataBlaster.Util.Sql;
 using Sitecore.Events;
@@ -243,7 +242,7 @@ namespace Sitecore.DataBlaster.Load
                     }
                 }
             }
-            loadContext.Log.Info($"Loaded data in database: {(int) stopwatch.Elapsed.TotalSeconds}s");
+            loadContext.Log.Info($"Loaded data in database: {(int)stopwatch.Elapsed.TotalSeconds}s");
             stopwatch.Restart();
             return true;
         }
@@ -275,7 +274,7 @@ namespace Sitecore.DataBlaster.Load
                 sqlContext.ExecuteSql(lookupItemsSql);
             }
 
-            loadContext.Log.Info($"Looked up ids: {(int) stopwatch.Elapsed.TotalSeconds}s");
+            loadContext.Log.Info($"Looked up ids: {(int)stopwatch.Elapsed.TotalSeconds}s");
         }
 
         protected virtual bool ValidateAndPrepareData(BulkLoadContext loadContext, BulkLoadSqlContext sqlContext)
@@ -296,7 +295,7 @@ namespace Sitecore.DataBlaster.Load
             if (!OnTempDataValidating.Execute(p => p.ValidateLoadStage(loadContext, sqlContext), breakOnDefault: true))
                 return false;
 
-            loadContext.Log.Info($"Validated and prepared loaded data: {(int) stopwatch.Elapsed.TotalSeconds}s");
+            loadContext.Log.Info($"Validated and prepared loaded data: {(int)stopwatch.Elapsed.TotalSeconds}s");
             return true;
         }
 
@@ -329,7 +328,7 @@ namespace Sitecore.DataBlaster.Load
                     }
                 }
             }
-            loadContext.Log.Info($"Merged loaded data: {(int) stopwatch.Elapsed.TotalSeconds}s");
+            loadContext.Log.Info($"Merged loaded data: {(int)stopwatch.Elapsed.TotalSeconds}s");
         }
 
         #endregion
@@ -343,7 +342,7 @@ namespace Sitecore.DataBlaster.Load
 
         protected virtual void OnSqlInfoMessage(BulkLoadContext context, object sender, SqlInfoMessageEventArgs args)
         {
-            foreach (var line in args.Message.Split(new[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var line in args.Message.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
             {
                 context.Log.Debug($"SQL Info: {line}");
             }
@@ -385,7 +384,7 @@ namespace Sitecore.DataBlaster.Load
                     return false;
                 }
 
-                var item = (BulkLoadItem) Current.Item;
+                var item = (BulkLoadItem)Current.Item;
                 ReadItemCount++;
 
                 if (!HasFieldDependencies && (Current.DependsOnCreate || Current.DependsOnUpdate))
@@ -427,27 +426,27 @@ namespace Sitecore.DataBlaster.Load
                 var versioned = Current as VersionedBulkField;
 
                 _fields[0] = Current.Item.Id;
-                _fields[1] = string.IsNullOrEmpty(Current.Item.Name) ? DBNull.Value : (object) Current.Item.Name;
-                _fields[2] = Current.Item.TemplateId != Guid.Empty ? (object) Current.Item.TemplateId : DBNull.Value;
-                _fields[3] = (object) item.TemplateName ?? DBNull.Value;
+                _fields[1] = string.IsNullOrEmpty(Current.Item.Name) ? DBNull.Value : (object)Current.Item.Name;
+                _fields[2] = Current.Item.TemplateId != Guid.Empty ? (object)Current.Item.TemplateId : DBNull.Value;
+                _fields[3] = (object)item.TemplateName ?? DBNull.Value;
                 _fields[4] = Current.Item.MasterId;
                 _fields[5] = Current.Item.ParentId;
-                _fields[6] = (object) item.ItemPath ?? DBNull.Value;
-                _fields[7] = (object) item.ItemLookupPath ?? DBNull.Value;
-                _fields[8] = (object) item.DependsOnItemCreation ?? DBNull.Value;
+                _fields[6] = (object)item.ItemPath ?? DBNull.Value;
+                _fields[7] = (object)item.ItemLookupPath ?? DBNull.Value;
+                _fields[8] = (object)item.DependsOnItemCreation ?? DBNull.Value;
                 _fields[9] = Current.Item.Id;
 
                 _fields[10] = item.LoadAction.ToString();
                 _fields[11] = item.SourceInfo ?? DBNull.Value;
 
                 _fields[12] = Current.Id;
-                _fields[13] = (object) Current.Name ?? DBNull.Value;
-                _fields[14] = unversioned != null ? (object) unversioned.Language : DBNull.Value;
-                _fields[15] = versioned != null ? (object) versioned.Version : DBNull.Value;
-                _fields[16] = Current.Value != null ? (object) Current.Value : DBNull.Value;
+                _fields[13] = (object)Current.Name ?? DBNull.Value;
+                _fields[14] = unversioned != null ? (object)unversioned.Language : DBNull.Value;
+                _fields[15] = versioned != null ? (object)versioned.Version : DBNull.Value;
+                _fields[16] = Current.Value != null ? (object)Current.Value : DBNull.Value;
 
                 // Data for blob will be fetched through GetStream method.
-                _fields[17] = Current.Blob != null ? (object) null : DBNull.Value;
+                _fields[17] = Current.Blob != null ? (object)null : DBNull.Value;
                 _fields[18] = Current.IsBlob;
 
                 _fields[19] = fieldAction.ToString();

--- a/src/Sitecore.DataBlaster/Load/ItemChange.cs
+++ b/src/Sitecore.DataBlaster/Load/ItemChange.cs
@@ -33,7 +33,7 @@ namespace Sitecore.DataBlaster.Load
             ParentId = record.GetGuid(4);
             OriginalParentId = record.GetGuid(5);
             Language = record.IsDBNull(6) ? null : record.GetString(6);
-            Version = record.IsDBNull(7) ? (int?) null : record.GetInt32(7);
+            Version = record.IsDBNull(7) ? (int?)null : record.GetInt32(7);
             Created = record.IsDBNull(8) ? false : record.GetBoolean(8);
             Saved = record.IsDBNull(9) ? false : record.GetBoolean(9);
             Moved = record.IsDBNull(10) ? false : record.GetBoolean(10);

--- a/src/Sitecore.DataBlaster/Load/Links/BulkItemLinkParser.cs
+++ b/src/Sitecore.DataBlaster/Load/Links/BulkItemLinkParser.cs
@@ -54,14 +54,14 @@ namespace Sitecore.DataBlaster.Load.Links
                 .Select(x =>
                 {
                     ID id;
-                    return ID.TryParse(x.Value, out id) ? id : (ID) null;
+                    return ID.TryParse(x.Value, out id) ? id : (ID)null;
                 })
                 .Concat(LinkRegex.Value.Matches(field.Value).Cast<Match>().Select(x =>
                 {
                     Guid guid;
-                    return Guid.TryParse(x.Value, out guid) ? new ID(guid) : (ID) null;
+                    return Guid.TryParse(x.Value, out guid) ? new ID(guid) : (ID)null;
                 }))
-                .Where(x => x != (ID) null);
+                .Where(x => x != (ID)null);
 
             foreach (var link in ids
                 .Select(x => new BulkItemLink(

--- a/src/Sitecore.DataBlaster/Load/Paths/AncestorGenerator.cs
+++ b/src/Sitecore.DataBlaster/Load/Paths/AncestorGenerator.cs
@@ -46,7 +46,7 @@ namespace Sitecore.DataBlaster.Load.Paths
 
             // Detect all the ancestors to generate.
             var ancestorNames = item.ItemPath.Substring(root.ItemPath.Length)
-                .Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
+                .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             ancestorNames = ancestorNames.Take(ancestorNames.Length - 1).ToArray(); // Don't include item.
 
             // Generate all ancestors.

--- a/src/Sitecore.DataBlaster/Load/Processors/ChangeCacheClearer.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/ChangeCacheClearer.cs
@@ -35,7 +35,7 @@ namespace Sitecore.DataBlaster.Load.Processors
             else
             {
                 _cachUtil.RemoveItemsFromCachesInBulk(db, GetCacheClearEntries(loadContext.ItemChanges));
-                loadContext.Log.Info($"Items removed from cache: {(int) stopwatch.Elapsed.TotalSeconds}s");
+                loadContext.Log.Info($"Items removed from cache: {(int)stopwatch.Elapsed.TotalSeconds}s");
             }
         }
 

--- a/src/Sitecore.DataBlaster/Load/Processors/ChangeIndexer.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/ChangeIndexer.cs
@@ -31,7 +31,7 @@ namespace Sitecore.DataBlaster.Load.Processors
             var stopwatch = Stopwatch.StartNew();
 
             UpdateIndexes(loadContext, changes);
-            loadContext.Log.Info($"Updated content search indexes: {(int) stopwatch.Elapsed.TotalSeconds}s");
+            loadContext.Log.Info($"Updated content search indexes: {(int)stopwatch.Elapsed.TotalSeconds}s");
 
             loadContext.OnDataIndexed?.Invoke(loadContext, changes);
             Event.RaiseEvent("bulkloader:dataindexed", loadContext);
@@ -59,7 +59,7 @@ namespace Sitecore.DataBlaster.Load.Processors
             }
 
             var touchedPercentage =
-                (uint) Math.Ceiling((double) itemChanges.Count / Math.Max(1, index.Summary.NumberOfDocuments) * 100);
+                (uint)Math.Ceiling((double)itemChanges.Count / Math.Max(1, index.Summary.NumberOfDocuments) * 100);
             if (context.IndexRebuildThresholdPercentage.HasValue
                 && touchedPercentage > context.IndexRebuildThresholdPercentage.Value)
             {

--- a/src/Sitecore.DataBlaster/Load/Processors/ItemLinker.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/ItemLinker.cs
@@ -41,7 +41,7 @@ namespace Sitecore.DataBlaster.Load.Processors
             // so we assume that the same set will be presented again after a crash.
             UpdateLinkDatabase(loadContext, sqlContext, GetItemLinksFromContext(loadContext), changes);
 
-            loadContext.Log.Info($"Updated link database: {(int) stopwatch.Elapsed.TotalSeconds}s");
+            loadContext.Log.Info($"Updated link database: {(int)stopwatch.Elapsed.TotalSeconds}s");
         }
 
         protected virtual LinkedList<BulkItemLink> GetItemLinksFromContext(BulkLoadContext context)
@@ -68,7 +68,7 @@ namespace Sitecore.DataBlaster.Load.Processors
             var createLinkTempTable = sqlContext.GetEmbeddedSql(loadContext, "Sql.20.CreateLinkTempTable.sql");
             var mergeLinkData = sqlContext.GetEmbeddedSql(loadContext, "Sql.21.MergeLinkTempData.sql");
 
-            var connectionString = ((SqlServerLinkDatabase) Factory.GetLinkDatabase()).ConnectionString;
+            var connectionString = ((SqlServerLinkDatabase)Factory.GetLinkDatabase()).ConnectionString;
             using (var conn = new SqlConnection(connectionString))
             {
                 conn.Open();
@@ -123,15 +123,15 @@ namespace Sitecore.DataBlaster.Load.Processors
 
                 _fields[0] = Current.SourceDatabaseName;
                 _fields[1] = Current.SourceItemID.Guid;
-                _fields[2] = (object) Current.SourceItemLanguage?.Name ?? DBNull.Value;
-                _fields[3] = (object) Current.SourceItemVersion?.Number ?? DBNull.Value;
+                _fields[2] = (object)Current.SourceItemLanguage?.Name ?? DBNull.Value;
+                _fields[3] = (object)Current.SourceItemVersion?.Number ?? DBNull.Value;
                 _fields[4] = Current.SourceFieldID.Guid;
 
                 _fields[5] = Current.TargetDatabaseName;
                 _fields[6] = Current.TargetItemID.Guid;
-                _fields[7] = (object) Current.TargetItemLanguage?.Name ?? DBNull.Value;
-                _fields[8] = (object) Current.TargetItemVersion?.Number ?? DBNull.Value;
-                _fields[9] = (object) Current.TargetPath ?? DBNull.Value;
+                _fields[7] = (object)Current.TargetItemLanguage?.Name ?? DBNull.Value;
+                _fields[8] = (object)Current.TargetItemVersion?.Number ?? DBNull.Value;
+                _fields[9] = (object)Current.TargetPath ?? DBNull.Value;
 
                 _fields[10] = Current.ItemAction.ToString();
 

--- a/src/Sitecore.DataBlaster/Load/Processors/SyncHistoryTable.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/SyncHistoryTable.cs
@@ -24,7 +24,7 @@ namespace Sitecore.DataBlaster.Load.Processors
             sqlContext.ExecuteSql(sql,
                 commandProcessor: cmd => cmd.Parameters.AddWithValue("@UserName", Sitecore.Context.User.Name));
 
-            loadContext.Log.Info($"Updated history: {(int) stopwatch.Elapsed.TotalSeconds}s");
+            loadContext.Log.Info($"Updated history: {(int)stopwatch.Elapsed.TotalSeconds}s");
         }
 
         private bool HistoryEngineEnabled(BulkLoadContext context)

--- a/src/Sitecore.DataBlaster/Load/Processors/SyncPublishQueue.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/SyncPublishQueue.cs
@@ -16,7 +16,7 @@ namespace Sitecore.DataBlaster.Load.Processors
             sqlContext.ExecuteSql(sql,
                 commandProcessor: cmd => cmd.Parameters.AddWithValue("@UserName", Sitecore.Context.User.Name));
 
-            loadContext.Log.Info($"Updated publish queue: {(int) stopwatch.Elapsed.TotalSeconds}s");
+            loadContext.Log.Info($"Updated publish queue: {(int)stopwatch.Elapsed.TotalSeconds}s");
         }
     }
 }

--- a/src/Sitecore.DataBlaster/Properties/AssemblyInfo.cs
+++ b/src/Sitecore.DataBlaster/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/Sitecore.DataBlaster/Read/BulkReader.cs
+++ b/src/Sitecore.DataBlaster/Read/BulkReader.cs
@@ -216,7 +216,7 @@ namespace Sitecore.DataBlaster.Read
                             reader.GetGuid(3), reader.GetGuid(4), reader.GetGuid(5), reader.GetString(2));
 
                     var language = reader.IsDBNull(10) ? null : reader.GetString(10);
-                    var version = reader.IsDBNull(11) ? null : (int?) reader.GetInt32(11);
+                    var version = reader.IsDBNull(11) ? null : (int?)reader.GetInt32(11);
 
                     if (language != null && version != null)
                         item.AddVersionedField(reader.GetGuid(8), language, version.Value, reader.GetString(9));

--- a/src/Sitecore.DataBlaster/Util/CacheUtil.cs
+++ b/src/Sitecore.DataBlaster/Util/CacheUtil.cs
@@ -17,8 +17,8 @@ namespace Sitecore.DataBlaster.Util
         public virtual void RemoveItemFromCaches(Database database, ID itemId, ID parentId, string itemPath = null)
         {
             if (database == null) throw new ArgumentNullException(nameof(database));
-            if (itemId == (ID) null) throw new ArgumentNullException(nameof(itemId));
-            if (parentId == (ID) null) throw new ArgumentNullException(nameof(parentId));
+            if (itemId == (ID)null) throw new ArgumentNullException(nameof(itemId));
+            if (parentId == (ID)null) throw new ArgumentNullException(nameof(parentId));
 
             // Parent needs to be cleared because it holds a reference to its children.
             var parentPath = itemPath?.Substring(0, itemPath.LastIndexOf("/", StringComparison.Ordinal));
@@ -50,7 +50,7 @@ namespace Sitecore.DataBlaster.Util
             Parallel.ForEach(itemIdParentIdAndItemPaths,
                 new ParallelOptions
                 {
-                    MaxDegreeOfParallelism = (int) maxDegreeOfParallelism
+                    MaxDegreeOfParallelism = (int)maxDegreeOfParallelism
                 },
                 x => { RemoveItemFromCaches(database, x.Item1, x.Item2, x.Item3); });
         }
@@ -58,7 +58,7 @@ namespace Sitecore.DataBlaster.Util
         protected virtual void RemoveItemFromCaches(Database database, ID itemId, string itemPath = null)
         {
             if (database == null) throw new ArgumentNullException(nameof(database));
-            if (itemId == (ID) null) throw new ArgumentNullException(nameof(itemId));
+            if (itemId == (ID)null) throw new ArgumentNullException(nameof(itemId));
 
             var dbCaches = database.Caches;
 
@@ -80,7 +80,7 @@ namespace Sitecore.DataBlaster.Util
         protected virtual IEnumerable<Item> GetCachedItems(DatabaseCaches caches, ID itemId)
         {
             if (caches == null) throw new ArgumentNullException(nameof(caches));
-            if (itemId == (ID) null) throw new ArgumentNullException(nameof(itemId));
+            if (itemId == (ID)null) throw new ArgumentNullException(nameof(itemId));
 
             var info = caches.DataCache.GetItemInformation(itemId);
             var languages = info?.GetLanguages();

--- a/src/Sitecore.DataBlaster/Util/Chain.cs
+++ b/src/Sitecore.DataBlaster/Util/Chain.cs
@@ -164,7 +164,7 @@ namespace Sitecore.DataBlaster.Util
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable) _processors).GetEnumerator();
+            return ((IEnumerable)_processors).GetEnumerator();
         }
 
         #endregion

--- a/src/Sitecore.DataBlaster/Util/GuidUtility.cs
+++ b/src/Sitecore.DataBlaster/Util/GuidUtility.cs
@@ -62,7 +62,7 @@ namespace Sitecore.DataBlaster.Util
 
             // comput the hash of the name space ID concatenated with the name (step 4)
             byte[] hash;
-            using (HashAlgorithm algorithm = version == 3 ? (HashAlgorithm) MD5.Create() : SHA1.Create())
+            using (HashAlgorithm algorithm = version == 3 ? (HashAlgorithm)MD5.Create() : SHA1.Create())
             {
                 algorithm.TransformBlock(namespaceBytes, 0, namespaceBytes.Length, null, 0);
                 algorithm.TransformFinalBlock(nameBytes, 0, nameBytes.Length);
@@ -74,10 +74,10 @@ namespace Sitecore.DataBlaster.Util
             Array.Copy(hash, 0, newGuid, 0, 16);
 
             // set the four most significant bits (bits 12 through 15) of the time_hi_and_version field to the appropriate 4-bit version number from Section 4.1.3 (step 8)
-            newGuid[6] = (byte) ((newGuid[6] & 0x0F) | (version << 4));
+            newGuid[6] = (byte)((newGuid[6] & 0x0F) | (version << 4));
 
             // set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and one, respectively (step 10)
-            newGuid[8] = (byte) ((newGuid[8] & 0x3F) | 0x80);
+            newGuid[8] = (byte)((newGuid[8] & 0x3F) | 0x80);
 
             // convert the resulting UUID to local byte order (step 13)
             SwapByteOrder(newGuid);

--- a/src/Sitecore.DataBlaster/Util/Sql/SqlContext.cs
+++ b/src/Sitecore.DataBlaster/Util/Sql/SqlContext.cs
@@ -117,7 +117,7 @@ namespace Sitecore.DataBlaster.Util.Sql
         {
             var commands = splitOnGoCommands
                 ? Regex.Split(sql, @"^\s*GO\s*$", RegexOptions.Multiline | RegexOptions.IgnoreCase)
-                : new[] {sql};
+                : new[] { sql };
 
             foreach (var command in commands)
             {

--- a/src/Unicorn.DataBlaster/Properties/AssemblyInfo.cs
+++ b/src/Unicorn.DataBlaster/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/Unicorn.DataBlaster/Sync/DataBlasterParameters.cs
+++ b/src/Unicorn.DataBlaster/Sync/DataBlasterParameters.cs
@@ -26,7 +26,7 @@ namespace Unicorn.DataBlaster.Sync
         /// Flag to skip post processing of Unicorn like e.g. publishing.
         /// </summary>
         public bool SkipUnicornSyncEnd { get; set; }
-        
+
         /// <summary>
         /// Force this BulkLoadAction to be used during item extraction instead of the BulkLoadAction derived from the configured evaluator.
         /// </summary>

--- a/src/Unicorn.DataBlaster/Sync/ItemMapper.cs
+++ b/src/Unicorn.DataBlaster/Sync/ItemMapper.cs
@@ -1,8 +1,8 @@
-﻿using Rainbow.Model;
+﻿using System;
+using System.IO;
+using Rainbow.Model;
 using Sitecore;
 using Sitecore.DataBlaster.Load;
-using System;
-using System.IO;
 using Convert = System.Convert;
 
 namespace Unicorn.DataBlaster.Sync

--- a/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
+++ b/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
@@ -9,12 +9,12 @@ using Sitecore.Pipelines;
 using Unicorn.Configuration;
 using Unicorn.DataBlaster.Logging;
 using Unicorn.Loader;
+using Unicorn.Logging;
 using Unicorn.Pipelines.UnicornSyncComplete;
 using Unicorn.Pipelines.UnicornSyncEnd;
 using Unicorn.Pipelines.UnicornSyncStart;
 using Unicorn.Predicates;
 using Unicorn.Publishing;
-using ILogger = Unicorn.Logging.ILogger;
 
 namespace Unicorn.DataBlaster.Sync
 {
@@ -96,11 +96,11 @@ namespace Unicorn.DataBlaster.Sync
                 var startTimestamp = DateTime.Now;
 
                 LoadItems(args.Configurations, parameters, args.Logger);
-                args.Logger.Info($"Extracted and loaded items ({(int) watch.Elapsed.TotalMilliseconds}ms)");
+                args.Logger.Info($"Extracted and loaded items ({(int)watch.Elapsed.TotalMilliseconds}ms)");
 
                 watch.Restart();
                 ClearCaches();
-                args.Logger.Info($"Caches cleared ({(int) watch.Elapsed.TotalMilliseconds}ms)");
+                args.Logger.Info($"Caches cleared ({(int)watch.Elapsed.TotalMilliseconds}ms)");
 
                 ExecuteUnicornSyncComplete(args, parameters, startTimestamp);
                 ExecuteUnicornSyncEnd(args, parameters);
@@ -177,7 +177,7 @@ namespace Unicorn.DataBlaster.Sync
                 CorePipeline.Run("unicornSyncComplete",
                     new UnicornSyncCompletePipelineArgs(config, syncStartTimestamp));
             }
-            args.Logger.Info($"Ran sync complete pipelines ({(int) watch.Elapsed.TotalMilliseconds}ms)");
+            args.Logger.Info($"Ran sync complete pipelines ({(int)watch.Elapsed.TotalMilliseconds}ms)");
         }
 
         protected virtual void ExecuteUnicornSyncEnd(UnicornSyncStartPipelineArgs args,
@@ -188,7 +188,7 @@ namespace Unicorn.DataBlaster.Sync
             // When we tell Unicorn that sync is handled, end pipeline is not called anymore.
             var watch = Stopwatch.StartNew();
             CorePipeline.Run("unicornSyncEnd", new UnicornSyncEndPipelineArgs(args.Logger, true, args.Configurations));
-            args.Logger.Info($"Ran sync end pipeline ({(int) watch.Elapsed.TotalMilliseconds}ms)");
+            args.Logger.Info($"Ran sync end pipeline ({(int)watch.Elapsed.TotalMilliseconds}ms)");
         }
 
         protected virtual BulkLoadContext CreateBulkLoadContext(BulkLoader bulkLoader, string databaseName,


### PR DESCRIPTION
The following styling has been fixed:
Sort order of usings
Spaces instead of tabs (4 for code 2 for configs/xml files)