### PR TITLE
Check on the processor which is also used by default Unicorn to fill …

### DIFF
--- a/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
+++ b/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
@@ -31,10 +31,10 @@ namespace Unicorn.DataBlaster.Sync
             {
                 if (_isUnicornPublishEnabled == null)
                 {
-                    _isUnicornPublishEnabled = Factory.GetConfigNode("//sitecore/pipelines/unicornSyncEnd/processor")?
+                    _isUnicornPublishEnabled = Factory.GetConfigNode("//sitecore/pipelines/unicornSyncComplete/processor")?
                                                    .Attributes?["type"]?.Value
                                                    .StartsWith(
-                                                       "Unicorn.Pipelines.UnicornSyncEnd.TriggerAutoPublishSyncedItems") ??
+                                                       "Unicorn.Pipelines.UnicornSyncComplete.AddSyncedItemsToPublishQueue") ??
                                                false;
                 }
 


### PR DESCRIPTION
The current code now checks if the automated publish trigger is enabled or not. But the unicorn code has another processor which fills the publish queue, the AddSyncedItemsToPublishQueue. So it should check this one to be consistent with Unicorn default behavior.