### PR TITLE
Features/sitecore 93

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,14 +4,17 @@
     <MsBuildAllProjects>$(MsBuildAllProjects);$(MsBuildThisFileFullPath)</MsBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Edit this value to change the current major.minor version -->
-    <VersionPrefix>1.1</VersionPrefix>
+    <!-- Edit this value to change the current major.minor version 
+         The first 3 versions follow the Sitecore release.
+         The fourth indicates our major revision (e.g. breaking changes) for that Sitecore release.
+    -->
+    <VersionPrefix>9.3.0.1</VersionPrefix>
 
     <!-- Append the ever incrementing build number if it is available -->
     <VersionPrefix Condition=" '$(BUILD_BUILDID)' != '' ">$(VersionPrefix).$(BUILD_BUILDID)</VersionPrefix>
 
     <!-- Common NuGet package properties. -->
-    <Copyright>Copyright © 2019</Copyright>
+    <Copyright>Copyright © 2020</Copyright>
     <Company>delaware digital</Company>
     <Authors>delaware-digital</Authors>
     <License>http://opensource.org/licenses/MIT</License>

--- a/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
+++ b/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
@@ -5,7 +5,6 @@ using log4net;
 using Sitecore.Buckets.Util;
 using Sitecore.ContentSearch;
 using Sitecore.Data.Items;
-using Sitecore.DataBlaster.Util;
 using Sitecore.Diagnostics;
 
 namespace Sitecore.DataBlaster.Load
@@ -194,15 +193,14 @@ namespace Sitecore.DataBlaster.Load
             LookupItemsIn(item.ID.Guid, item.Paths.Path);
         }
 
-        public bool ShouldUpdateIndex(ISearchIndex searchIndex)
+        public bool ShouldUpdateIndex(ISearchIndex searchIndex, ISearchIndexSummary searchIndexSummary)
         {
             // Always update when index has been explicitly set as to update
             if (_indexesToUpdate != null && _indexesToUpdate.Contains(searchIndex))
                 return true;
 
-            // Only rebuild when index is not empty
-            var summary = searchIndex.RequestSummary();
-            return summary == null || summary.NumberOfDocuments > 0;
+            // Only update when index is not empty
+            return searchIndexSummary.NumberOfDocuments > 0;
         }
 
         #region Stage results and feedback

--- a/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
+++ b/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
@@ -5,6 +5,7 @@ using log4net;
 using Sitecore.Buckets.Util;
 using Sitecore.ContentSearch;
 using Sitecore.Data.Items;
+using Sitecore.DataBlaster.Util;
 using Sitecore.Diagnostics;
 
 namespace Sitecore.DataBlaster.Load
@@ -200,7 +201,8 @@ namespace Sitecore.DataBlaster.Load
                 return true;
 
             // Only rebuild when index is not empty
-            return searchIndex.Summary.NumberOfDocuments > 0;
+            var summary = searchIndex.RequestSummary();
+            return summary == null || summary.NumberOfDocuments > 0;
         }
 
         #region Stage results and feedback

--- a/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
+++ b/src/Sitecore.DataBlaster/Load/BulkLoadContext.cs
@@ -199,7 +199,7 @@ namespace Sitecore.DataBlaster.Load
             if (_indexesToUpdate != null && _indexesToUpdate.Contains(searchIndex))
                 return true;
 
-            // Only update when index is not empty
+            // Only update when index is not empty: updating an empty index would trigger a rebuild.
             return searchIndexSummary.NumberOfDocuments > 0;
         }
 

--- a/src/Sitecore.DataBlaster/Load/Processors/ChangeIndexer.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/ChangeIndexer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Sitecore.Abstractions;
 using Sitecore.Configuration;
 using Sitecore.ContentSearch;
 using Sitecore.ContentSearch.Maintenance;
@@ -10,7 +11,6 @@ using Sitecore.Data.Managers;
 using Sitecore.DataBlaster.Load.Sql;
 using Sitecore.Events;
 using Sitecore.Globalization;
-using Sitecore.Jobs;
 
 namespace Sitecore.DataBlaster.Load.Processors
 {
@@ -50,7 +50,7 @@ namespace Sitecore.DataBlaster.Load.Processors
         protected virtual void UpdateIndex(BulkLoadContext context, ICollection<ItemChange> itemChanges,
             Database database, ISearchIndex index)
         {
-            Job job = null;
+            BaseJob job = null;
 
             if (!context.ShouldUpdateIndex(index))
             {

--- a/src/Sitecore.DataBlaster/Load/Processors/ChangeIndexer.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/ChangeIndexer.cs
@@ -61,7 +61,7 @@ namespace Sitecore.DataBlaster.Load.Processors
             }
             if (!context.ShouldUpdateIndex(index, indexSummary))
             {
-                context.Log.Warn($"Skipping updating index '{index.Name}' because its empty.");
+                context.Log.Warn($"Skipping updating index '{index.Name}' because it's empty.");
                 return;
             }
 

--- a/src/Sitecore.DataBlaster/Load/Processors/ChangeIndexer.cs
+++ b/src/Sitecore.DataBlaster/Load/Processors/ChangeIndexer.cs
@@ -9,6 +9,7 @@ using Sitecore.ContentSearch.Maintenance;
 using Sitecore.Data;
 using Sitecore.Data.Managers;
 using Sitecore.DataBlaster.Load.Sql;
+using Sitecore.DataBlaster.Util;
 using Sitecore.Events;
 using Sitecore.Globalization;
 
@@ -58,8 +59,7 @@ namespace Sitecore.DataBlaster.Load.Processors
                 return;
             }
 
-            var touchedPercentage =
-                (uint)Math.Ceiling((double)itemChanges.Count / Math.Max(1, index.Summary.NumberOfDocuments) * 100);
+            uint touchedPercentage = GetTouchedPercentage(index, itemChanges);
             if (context.IndexRebuildThresholdPercentage.HasValue
                 && touchedPercentage > context.IndexRebuildThresholdPercentage.Value)
             {
@@ -131,6 +131,16 @@ namespace Sitecore.DataBlaster.Load.Processors
                 }));
 
             return identifiers;
+        }
+
+        /// <summary>
+        /// Returns the percentage of the index documents that where changed with the given list of item changes.
+        /// If an index can't tell us the total number of documents, we treat it as an empty index.
+        /// </summary>
+        private static uint GetTouchedPercentage(ISearchIndex index, ICollection<ItemChange> itemChanges)
+        {
+            var nrOfDocuments =index.RequestSummary()?.NumberOfDocuments ?? 0;
+            return (uint)Math.Ceiling((double)itemChanges.Count / Math.Max(1, nrOfDocuments) * 100);
         }
     }
 }

--- a/src/Sitecore.DataBlaster/Sitecore.DataBlaster.csproj
+++ b/src/Sitecore.DataBlaster/Sitecore.DataBlaster.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Sitecore.DataBlaster</PackageId>
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sitecore.Buckets.NoReferences" Version="8.2.170728" />
-    <PackageReference Include="Sitecore.ContentSearch.NoReferences" Version="8.2.170728" />
-    <PackageReference Include="Sitecore.Kernel.NoReferences" Version="8.2.170728" />
-    <PackageReference Include="Sitecore.Logging.NoReferences" Version="8.2.170728" />
+    <PackageReference Include="Sitecore.Buckets" Version="9.3.0" />
+    <PackageReference Include="Sitecore.ContentSearch" Version="9.3.0" />
+    <PackageReference Include="Sitecore.Kernel" Version="9.3.0" />
+    <PackageReference Include="Sitecore.Logging" Version="9.3.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Sitecore.DataBlaster/Util/CacheUtil.cs
+++ b/src/Sitecore.DataBlaster/Util/CacheUtil.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -8,7 +9,6 @@ using Sitecore.Configuration;
 using Sitecore.Data;
 using Sitecore.Data.DataProviders.Sql;
 using Sitecore.Data.Items;
-using Sitecore.Diagnostics;
 
 namespace Sitecore.DataBlaster.Util
 {

--- a/src/Sitecore.DataBlaster/Util/ISearchIndexExtensions.cs
+++ b/src/Sitecore.DataBlaster/Util/ISearchIndexExtensions.cs
@@ -11,8 +11,8 @@ namespace Sitecore.DataBlaster.Util
         /// </summary>
         public static ISearchIndexSummary RequestSummary(this ISearchIndex index)
         {
-            return index is BaseIndexSummaryClient baseIndex
-                ? baseIndex.RequestSummary()
+            return index is IIndexSummarySource summarSource
+                ? summarSource.GetClient().RequestSummary()
                 : null;
         }
     }

--- a/src/Sitecore.DataBlaster/Util/ISearchIndexExtensions.cs
+++ b/src/Sitecore.DataBlaster/Util/ISearchIndexExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Sitecore.ContentSearch;
+using Sitecore.ContentSearch.Summary;
+
+namespace Sitecore.DataBlaster.Util
+{
+    public static class ISearchIndexExtensions
+    {
+        /// <summary>
+        /// Sitecore moved summary from the interface to the <see cref="AbstractSearchIndex"/> base class.
+        /// but we only have access to the index from the <see cref="ContentSearchManager"/>.
+        /// </summary>
+        public static ISearchIndexSummary RequestSummary(this ISearchIndex index)
+        {
+            return index is BaseIndexSummaryClient baseIndex
+                ? baseIndex.RequestSummary()
+                : null;
+        }
+    }
+}

--- a/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
+++ b/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
@@ -31,11 +31,11 @@ namespace Unicorn.DataBlaster.Sync
             {
                 if (_isUnicornPublishEnabled == null)
                 {
-                    _isUnicornPublishEnabled = Factory.GetConfigNode("//sitecore/pipelines/unicornSyncEnd/processor")?
-                                                   .Attributes?["type"]?.Value
-                                                   .StartsWith(
-                                                       "Unicorn.Pipelines.UnicornSyncEnd.TriggerAutoPublishSyncedItems") ??
-                                               false;
+                    _isUnicornPublishEnabled = Factory
+                        .GetConfigNode("//sitecore/pipelines/unicornSyncEnd/processor")?
+                        .Attributes?["type"]?
+                        .Value
+                        .StartsWith("Unicorn.Pipelines.UnicornSyncEnd.TriggerAutoPublishSyncedItems") ?? false;
                 }
 
                 return _isUnicornPublishEnabled.Value;
@@ -147,12 +147,12 @@ namespace Unicorn.DataBlaster.Sync
                         .OrderBy(x => x.ItemPathLevel);
 
                     foreach (var itemChange in sortedItemChanges)
-					{
-						ManualPublishQueueHandler.AddItemToPublish(itemChange.ItemId);
-					}
-				}
-			}
-		}
+                    {
+                        ManualPublishQueueHandler.AddItemToPublish(itemChange.ItemId);
+                    }
+                }
+            }
+        }
 
         protected virtual void ClearCaches()
         {

--- a/src/Unicorn.DataBlaster/Unicorn.DataBlaster.csproj
+++ b/src/Unicorn.DataBlaster/Unicorn.DataBlaster.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Unicorn.DataBlaster</PackageId>
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sitecore.Kernel.NoReferences" Version="8.2.170728" />
-    <PackageReference Include="Sitecore.Logging.NoReferences" Version="8.2.170728" />
+    <PackageReference Include="Sitecore.Kernel" Version="9.3.0" />
+    <PackageReference Include="Sitecore.Logging" Version="9.3.0" />
     <PackageReference Include="Unicorn" Version="4.0.0" />
   </ItemGroup>
 

--- a/src/Unicorn.DataBlaster/Unicorn.DataBlaster.csproj
+++ b/src/Unicorn.DataBlaster/Unicorn.DataBlaster.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Sitecore.Kernel" Version="9.3.0" />
     <PackageReference Include="Sitecore.Logging" Version="9.3.0" />
-    <PackageReference Include="Unicorn" Version="4.0.0" />
+    <PackageReference Include="Unicorn" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Moving to Sitecore 9.3. DLLs because Jobs abstraction has been refactored.
Refactoring how to get the index summary.
Moving to .NET 4.7.1.
Introducing version number linked to Sitecore version.
