### PR TITLE
Features/readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ How to get started?
   <sitecore>
     <settings>
       <!-- Set this flag to disable the data blaster integration and fallback to 'regular' Unicorn. 
-                 If you want to temporarily disable the data blaster, you can do the following: 
-                    var helper = new SerializationHelper();
-                    helper.PipelineArgumentData[UnicornDataBlaster.PipelineArgsParametersKey] =
-		                new ExtendedDataBlasterParameters { DisableDataBlaster = true };
-                    helper.SyncConfigurations(...);
-                -->
-      <setting name="Unicorn.DisableDataBlaster" value="false" />
+           If you want to temporarily disable the data blaster, you can do the following: 
+             var helper = new SerializationHelper();
+             helper.PipelineArgumentData[UnicornDataBlaster.PipelineArgsParametersKey] =
+               new ExtendedDataBlasterParameters { DisableDataBlasterByDefault = true };
+             helper.SyncConfigurations(...);
+      -->
+      <setting name="Unicorn.DisableDataBlasterByDefault" value="false" />
     </settings>
     <pipelines>
       <unicornSyncStart>

--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ How to get started?
         <!-- Set this flag to false to update the global publish queue for incremental publishes. -->
         <SkipPublishQueue>true</SkipPublishQueue>
         <!-- Set this flag to true, to skip updating the link database. 
-                                The link database will be updated for all configs when there's at least one config set to update the link database. -->
+             The link database will be updated for all configs when there's at least one config set to update the link database.
+        -->
         <SkipLinkDatabase>false</SkipLinkDatabase>
         <!-- Set this flag to true, to skip updating the indexes. 
-                                The indexes will be updated for all configs when there's at least one config set to update the indexes. -->
+             The indexes will be updated for all configs when there's at least one config set to update the indexes.
+        -->
         <SkipIndexes>false</SkipIndexes>
       </unicornSyncStart>
     </pipelines>

--- a/src/Unicorn.DataBlaster/App_Config/Unicorn/Unicorn.DataBlaster.config
+++ b/src/Unicorn.DataBlaster/App_Config/Unicorn/Unicorn.DataBlaster.config
@@ -25,11 +25,11 @@
         <SkipPublishQueue>true</SkipPublishQueue>
 
         <!-- Set this flag to true, to skip updating the link database. 
-                        The link database will be updated for all configs when there's at least one config set to update the link database. -->
+             The link database will be updated for all configs when there's at least one config set to update the link database. -->
         <SkipLinkDatabase>false</SkipLinkDatabase>
 
         <!-- Set this flag to true, to skip updating the indexes. 
-                        The indexes will be updated for all configs when there's at least one config set to update the indexes. -->
+             The indexes will be updated for all configs when there's at least one config set to update the indexes. -->
         <SkipIndexes>false</SkipIndexes>
       </unicornSyncStart>
     </pipelines>

--- a/src/Unicorn.DataBlaster/App_Config/Unicorn/Unicorn.DataBlaster.config
+++ b/src/Unicorn.DataBlaster/App_Config/Unicorn/Unicorn.DataBlaster.config
@@ -4,12 +4,12 @@
   <sitecore>
     <settings>
       <!-- Set this flag to disable the data blaster integration and fallback to 'regular' Unicorn. 
-                 If you want to temporarily disable the data blaster, you can do the following: 
-                    var helper = new SerializationHelper();
-                    helper.PipelineArgumentData[UnicornDataBlaster.PipelineArgsParametersKey] =
-                    new ExtendedDataBlasterParameters { DisableDataBlaster = true };
-                    helper.SyncConfigurations(...);
-                -->
+           If you want to temporarily disable the data blaster, you can do the following: 
+             var helper = new SerializationHelper();
+             helper.PipelineArgumentData[UnicornDataBlaster.PipelineArgsParametersKey] =
+               new ExtendedDataBlasterParameters { DisableDataBlasterByDefault = true };
+             helper.SyncConfigurations(...);
+      -->
       <setting name="Unicorn.DisableDataBlasterByDefault" value="false" />
     </settings>
     <pipelines>

--- a/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
+++ b/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
@@ -98,13 +98,12 @@ namespace Unicorn.DataBlaster.Sync
         public virtual void Process(UnicornSyncStartPipelineArgs args)
         {
             // Find optional data blaster parameters in custom data of arguments.
-            object parms;
-            args.CustomData.TryGetValue(PipelineArgsParametersKey, out parms);
-            var parameters = parms as DataBlasterParameters;
+            args.CustomData.TryGetValue(PipelineArgsParametersKey, out var parms);
+            var parameters = parms as DataBlasterParameters ?? new DataBlasterParameters();
 
             // If not enabled by default, is DataBlaster enabled through parameters?
-            if (Settings.GetBoolSetting(DisableDataBlasterSettingName, false) &&
-                (parameters == null || !parameters.EnableDataBlaster)) return;
+            if (Settings.GetBoolSetting(DisableDataBlasterSettingName, false) && !parameters.EnableDataBlaster)
+                return;
 
             try
             {

--- a/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
+++ b/src/Unicorn.DataBlaster/Sync/UnicornDataBlaster.cs
@@ -70,11 +70,30 @@ namespace Unicorn.DataBlaster.Sync
         /// <remarks>If not skipped and at least one config nneds to update the indexes, it's updated for all configs.</remarks>
         public bool SkipIndexes { get; set; } = false;
 
-        public UnicornDataBlaster(BulkLoader bulkLoader = null, ItemExtractor itemExtractor = null)
+        #region Explicit ctors to support Sitecore.Configuration.DefaultFactory.CreateFromTypeName
+
+        public UnicornDataBlaster()
+            : this(new BulkLoader(), new ItemExtractor())
         {
-            BulkLoader = bulkLoader ?? new BulkLoader();
-            ItemExtractor = itemExtractor ?? new ItemExtractor();
         }
+
+        public UnicornDataBlaster(BulkLoader bulkLoader)
+            : this(bulkLoader, new ItemExtractor())
+        {
+        }
+
+        public UnicornDataBlaster(ItemExtractor itemExtractor)
+            : this(new BulkLoader(), itemExtractor)
+        {
+        }
+
+        public UnicornDataBlaster(BulkLoader bulkLoader, ItemExtractor itemExtractor)
+        {
+            BulkLoader = bulkLoader;
+            ItemExtractor = itemExtractor;
+        }
+
+        #endregion
 
         public virtual void Process(UnicornSyncStartPipelineArgs args)
         {


### PR DESCRIPTION
Renamed 'DisableDataBlaster' to 'DisableDataBlasterByDefault' in documentation.

Added additional constructors for UnicornDataBlaster because Sitecore's CreateFromTypeName doesn't support optional parameters. This should fix our README sample code.

Ensure DataBlasterParameter is never null (by creating a default instance) because called methods don't expect it.