### PR TITLE
Bump Unicorn to 4.1.2, which has better Sitecore 9.3 support

### DIFF
--- a/src/Unicorn.DataBlaster/Unicorn.DataBlaster.csproj
+++ b/src/Unicorn.DataBlaster/Unicorn.DataBlaster.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Sitecore.Kernel" Version="9.3.0" />
     <PackageReference Include="Sitecore.Logging" Version="9.3.0" />
-    <PackageReference Include="Unicorn" Version="4.1.1" />
+    <PackageReference Include="Unicorn" Version="4.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Referencing [Unicorn 4.1.2](https://github.com/SitecoreUnicorn/Unicorn/releases/tag/4.1.2), as it contains a fix for the SerializationFinishedEvent not raised on deserialize end in Sitecore 9.3 (and up).

See
- [Sitecore hangs after SendSerializationCompleteEvent is triggered](https://github.com/SitecoreUnicorn/Unicorn/issues/378)
- [SendSerializationCompleteEvent not raised properly in Sitecore 9.2](https://github.com/SitecoreUnicorn/Unicorn/issues/370)